### PR TITLE
feat: Support Jekyll `baseurl` setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 .bundle
+/.idea/
 .jekyll-cache
 .sass-cache
 _site

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
         <div class="nz-govt-logo" style="display: flex; align-items: center;">
             <a rel="noopener" href="http://www.govt.nz/" target="_blank"
                 aria-label="New Zealand Government">
-                <img src="/assets/images/nz-govt-logo-rev.svg" />
+                <img src="{{ '/assets/images/nz-govt-logo-rev.svg' | relative_url }}" />
             </a>
         </div>
         <div class="justify-end">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/assets/lui.css">
-    <link rel="stylesheet" href="/assets/lui-override.css">
-    <link rel="stylesheet" href="/assets/syntax.css">
+    <link rel="stylesheet" href="{{ '/assets/lui.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/lui-override.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/syntax.css' | relative_url }}">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="lui-header">
     <div class="lui-header-row">
         <div class="lui-header-col">
-            <div class="lui-header-logo"><img class="linz-logo" src="/assets/images/linz-logo-col-n-white-txt.svg" /></div>
+            <div class="lui-header-logo"><img class="linz-logo" src="{{ '/assets/images/linz-logo-col-n-white-txt.svg' | relative_url }}" /></div>
             <div class="lui-header-title">
                 <h1>{{ site.title | escape }}</h1>
             </div>


### PR DESCRIPTION
Necessary for https://linz.github.io/emergency-management-tools/ to find its assets.