### PR TITLE
chore: remove copyright date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Land Information New Zealand on behalf of the New Zealand Government.
+Copyright (c) Land Information New Zealand on behalf of the New Zealand Government.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
         </div>
         <div class="justify-end">
             <ul class="lui-footer-list">
-                <li class="lui-footer-inline-list-item">© 2021 Land Information New Zealand</li>
+                <li class="lui-footer-inline-list-item">© Land Information New Zealand</li>
                 <li class="lui-footer-inline-list-item">
                     <a rel="noopener" target="_blank"
                         href="https://www.linz.govt.nz/contact-us">Contact</a>


### PR DESCRIPTION
The copyright date is not useful. We did remove it in [some places](https://github.com/linz/imagery/blob/master/LICENSE#L3).